### PR TITLE
Update CI & android e2e config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,17 +77,17 @@ jobs:
         run: yarn e2e test:ios
 
   run-e2e-android:
-    runs-on: 'macos-latest' # This is important, linux cannot run the emulator graphically for e2e tests
+    runs-on: 'macos-13' # This is important, linux cannot run the emulator graphically for e2e tests
     strategy:
       matrix:
-        api-level: [21]
+        api-level: [29]
         profile: ['pixel_xl']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
-          java-version: '11'
+          distribution: 'temurin'
+          java-version: '17'
           cache: 'gradle'
 
       - name: Gradle cache
@@ -113,8 +113,9 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           profile: ${{matrix.profile}}
-          name: Pixel_API_21_AOSP
-          target: default
+          avd-name: Pixel_API_29_GOOGLE
+          arch: x86_64
+          target: google_apis
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
@@ -147,8 +148,8 @@ jobs:
         with:
           api-level: ${{ matrix.api-level }}
           profile: ${{matrix.profile}}
-          avd-name: Pixel_API_21_AOSP
-          target: default
+          avd-name: Pixel_API_29_GOOGLE
+          target: google_apis
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true


### PR DESCRIPTION
android ci task is [failing](https://github.com/ht-sdks/events-sdk-react-native/actions/runs/19447118270/job/55644111660?pr=2) 

- update to actions cache v4
- update to android api 29 & jdk 17
- use `macos-13` & specify `x86` for stability (was failing on `macos-latest` and arm64)