### PR TITLE
fix(sovran): call onInitialized when persistence restore fails

### DIFF
--- a/packages/sovran/src/__tests__/store.test.ts
+++ b/packages/sovran/src/__tests__/store.test.ts
@@ -339,6 +339,39 @@ describe('Sovran', () => {
       expect(mockPesistor.set).toHaveBeenCalledWith(ID, expectedState);
     });
 
+    it('calls onInitialized with default state when persistor.get rejects', async () => {
+      const failingPersistor: Persistor = {
+        get: jest.fn().mockRejectedValue(new Error('Storage corrupted')),
+        set: jest.fn(),
+      };
+
+      const onInitialized = jest.fn();
+
+      createStore<EventStore>(
+        { events: [] },
+        {
+          persist: {
+            storeId: 'persistorTest',
+            persistor: failingPersistor,
+            onInitialized,
+          },
+        }
+      );
+
+      // The store's persistence init is a fire-and-forget promise chain:
+      // persistor.get().then(...).catch(...). Each link in that chain runs
+      // on a separate microtask tick. We need at least 2 ticks for the
+      // rejection to propagate through .then() and into .catch(); the 3rd
+      // is a safety margin.
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(failingPersistor.get).toHaveBeenCalledTimes(1);
+      expect(onInitialized).toHaveBeenCalledTimes(1);
+      expect(onInitialized).toHaveBeenCalledWith({ events: [] });
+    });
+
     it('saves initial state if storage is empty on startup', async () => {
       const ID = 'persistorTest';
       const INTERVAL = 5000;

--- a/packages/sovran/src/store.ts
+++ b/packages/sovran/src/store.ts
@@ -135,6 +135,7 @@ export const createStore = <T extends object>(
       })
       .catch((reason) => {
         console.warn(reason);
+        config?.persist?.onInitialized?.(getState());
       });
   }
 


### PR DESCRIPTION
When persistor.get() rejects (e.g. corrupted SQLite backing store), the .catch() handler logged a warning but never called onInitialized. This left the store permanently in a "not ready" state, which prevents the Analytics client from ever setting isReady=true. The SDK would silently accept events into the pending queue but never flush them, persisting across app restarts.

Call onInitialized with the default initial state in the .catch() path so the SDK can recover and continue operating. Persisted state from the corrupted store is lost, but new events will be processed and sent.

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persistence initialization behavior when `persistor.get` fails by marking the store as initialized with default state, which can affect readiness flows and drop corrupted persisted data. Low code complexity but touches startup/persistence error handling.
> 
> **Overview**
> Fixes a persistence-init edge case where a rejected `persistor.get()` would log a warning but leave the store uninitialized.
> 
> The `createStore` persistence `.catch()` path now calls `persist.onInitialized` with the current/default state, and adds a regression test asserting `onInitialized` fires on `get` failure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47f75e92bb134136a5c08470b32999ca0e3a3d5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Store now properly initializes with default state when storage retrieval fails, ensuring the app continues to function despite storage errors.

* **Tests**
  * Added test coverage to verify initialization completes successfully when storage operations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->