### PR TITLE
fix(ci): set authenticated remote URL before git push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,4 +63,5 @@ jobs:
           git add examples/E2E/yarn.lock
           git add examples/AnalyticsReactNativeExample/yarn.lock
           git commit -m "chore(release): update lockfiles [skip ci]" --no-verify
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
           git push

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,4 +63,4 @@ jobs:
           git add examples/E2E/yarn.lock
           git add examples/AnalyticsReactNativeExample/yarn.lock
           git commit -m "chore(release): update lockfiles [skip ci]" --no-verify
-          git push
+          git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git HEAD:${{ github.ref_name }}


### PR DESCRIPTION
## Summary
- The publish workflow's "Commit Updated App Locks" step fails on `git push` because `persist-credentials: false` in the checkout step strips the GITHUB_TOKEN from git's credential store.
- Rather than removing `persist-credentials: false` (which would expose credentials to all steps), this sets the authenticated remote URL only right before `git push`, scoping credentials to the step that needs them.

## Test plan
- [ ] Merge and trigger a publish via `workflow_dispatch`
- [ ] Verify the "Commit Updated App Locks" step completes successfully

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the publish workflow to perform authenticated, branch-targeted publishing for more reliable and secure release operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ht-sdks/events-sdk-react-native/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->