### PR TITLE
feat: Improve event uploading reliability

### DIFF
--- a/examples/AnalyticsReactNativeExample/App.tsx
+++ b/examples/AnalyticsReactNativeExample/App.tsx
@@ -15,6 +15,8 @@ import {
   // StartupFlushPolicy,
   // @ts-ignore unused for e2e tests
   // TimerFlushPolicy,
+  // @ts-ignore unused for e2e tests
+  // BackgroundFlushPolicy,
 } from '@ht-sdks/events-sdk-react-native';
 import Home from './Home';
 import SecondPage from './SecondPage';
@@ -42,6 +44,7 @@ const hightouchClient = createClient({
     // These are disabled for E2E tests
     // new TimerFlushPolicy(1000),
     // new StartupFlushPolicy(),
+    // new BackgroundFlushPolicy(),
   ],
 });
 

--- a/packages/core/src/__tests__/analytics.test.ts
+++ b/packages/core/src/__tests__/analytics.test.ts
@@ -204,7 +204,7 @@ describe('HightouchClient', () => {
       expect(flushPolicies.length).toBe(1);
     });
 
-    it('setting flushAt/Interval to 0 keeps only the lifecycle defaults', () => {
+    it('setting flushAt/Interval to 0 opts out of auto-flush entirely', () => {
       client = new HightouchClient({
         ...clientArgs,
         config: {
@@ -214,8 +214,8 @@ describe('HightouchClient', () => {
         },
       });
       const flushPolicies = client.getFlushPolicies();
-      // Startup + Background; pass `flushPolicies: []` to opt out entirely.
-      expect(flushPolicies.length).toBe(2);
+      // Disabling both Count and Timer skips the lifecycle defaults too.
+      expect(flushPolicies.length).toBe(0);
     });
 
     it('setting an empty array of policies should make the client have no uploads', () => {

--- a/packages/core/src/__tests__/analytics.test.ts
+++ b/packages/core/src/__tests__/analytics.test.ts
@@ -76,7 +76,13 @@ describe('HightouchClient', () => {
           return { remove: jest.fn() };
         });
 
-      client = new HightouchClient(clientArgs);
+      client = new HightouchClient({
+        ...clientArgs,
+        config: {
+          ...clientArgs.config,
+          flushPolicies: [],
+        },
+      });
 
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
@@ -180,7 +186,8 @@ describe('HightouchClient', () => {
         },
       });
       const flushPolicies = client.getFlushPolicies();
-      expect(flushPolicies.length).toBe(2);
+      // Count + Timer + Startup + Background
+      expect(flushPolicies.length).toBe(4);
     });
 
     it('setting flush policies is mutually exclusive with flushAt/Interval', () => {
@@ -197,7 +204,7 @@ describe('HightouchClient', () => {
       expect(flushPolicies.length).toBe(1);
     });
 
-    it('setting flushAt/Interval to 0 should make the client have no uploads', () => {
+    it('setting flushAt/Interval to 0 keeps only the lifecycle defaults', () => {
       client = new HightouchClient({
         ...clientArgs,
         config: {
@@ -207,7 +214,8 @@ describe('HightouchClient', () => {
         },
       });
       const flushPolicies = client.getFlushPolicies();
-      expect(flushPolicies.length).toBe(0);
+      // Startup + Background; pass `flushPolicies: []` to opt out entirely.
+      expect(flushPolicies.length).toBe(2);
     });
 
     it('setting an empty array of policies should make the client have no uploads', () => {

--- a/packages/core/src/__tests__/api.test.ts
+++ b/packages/core/src/__tests__/api.test.ts
@@ -64,6 +64,7 @@ describe('#sendEvents', () => {
 
     expect(fetch).toHaveBeenCalledWith(toUrl, {
       method: 'POST',
+      keepalive: true,
       body: JSON.stringify({
         batch: [event],
         sentAt: '2001-01-01T00:00:00.000Z',

--- a/packages/core/src/__tests__/internal/delivery.test.ts
+++ b/packages/core/src/__tests__/internal/delivery.test.ts
@@ -1,0 +1,504 @@
+import { AppState, AppStateStatus } from 'react-native';
+import type { Persistor } from '@ht-sdks/sovran-react-native';
+
+import { HightouchClient } from '../../analytics';
+import {
+  BackgroundFlushPolicy,
+  CountFlushPolicy,
+  StartupFlushPolicy,
+  type FlushPolicy,
+} from '../../flushPolicies';
+import { UtilityPlugin } from '../../plugin';
+import { SovranStorage } from '../../storage';
+import { getMockLogger } from '../../test-helpers';
+import { EventType, HightouchEvent, PluginType } from '../../types';
+
+jest.mock('react-native');
+jest.mock('uuid');
+
+type PersistedValue = Record<string, unknown> | undefined;
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+async function flushMicrotasks(count = 20) {
+  for (let i = 0; i < count; i++) {
+    await Promise.resolve();
+  }
+}
+
+async function wait(ms: number) {
+  await new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+class TestPersistor implements Persistor {
+  private values = new Map<string, unknown>();
+  private delayedGets = new Map<
+    string,
+    ReturnType<typeof deferred<PersistedValue>>
+  >();
+
+  delayGet(key: string) {
+    this.delayedGets.set(key, deferred<PersistedValue>());
+  }
+
+  resolveGet(key: string, value: PersistedValue) {
+    this.values.set(key, value);
+    this.delayedGets.get(key)?.resolve(value);
+    this.delayedGets.delete(key);
+  }
+
+  get = async <T>(key: string): Promise<T | undefined> => {
+    const delayed = this.delayedGets.get(key);
+    if (delayed !== undefined) {
+      return (await delayed.promise) as T | undefined;
+    }
+    return this.values.get(key) as T | undefined;
+  };
+
+  set = async <T>(key: string, state: T): Promise<void> => {
+    this.values.set(key, state);
+  };
+
+  peek<T>(key: string): T | undefined {
+    return this.values.get(key) as T | undefined;
+  }
+}
+
+function createClient({
+  writeKey,
+  persistor,
+  flushPolicies,
+  trackAppLifecycleEvents = false,
+}: {
+  writeKey: string;
+  persistor: Persistor;
+  flushPolicies: FlushPolicy[];
+  trackAppLifecycleEvents?: boolean;
+}) {
+  return new HightouchClient({
+    config: {
+      writeKey,
+      flushPolicies,
+      trackAppLifecycleEvents,
+      storePersistor: persistor,
+    },
+    logger: getMockLogger(),
+    store: new SovranStorage({
+      storeId: writeKey,
+      storePersistor: persistor,
+    }),
+  });
+}
+
+function expectUploadedEvent(fetchMock: jest.Mock, eventName: string) {
+  expect(fetchMock).toHaveBeenCalledWith(
+    expect.any(String),
+    expect.objectContaining({
+      body: expect.stringContaining(eventName),
+    })
+  );
+}
+
+function expectPersistedQueuedEvent(
+  persistor: TestPersistor,
+  writeKey: string,
+  eventName: string
+) {
+  const persistedQueue = persistor.peek<{ events: HightouchEvent[] }>(
+    `${writeKey}-events`
+  );
+  expect(persistedQueue?.events).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        type: EventType.TrackEvent,
+        event: eventName,
+      }),
+    ])
+  );
+}
+
+describe('event delivery', () => {
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    fetchMock = jest.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+    }));
+    global.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('uploads events restored from the persisted destination queue on startup', async () => {
+    const writeKey = 'startup-restore-key';
+    const persistor = new TestPersistor();
+    const queueKey = `${writeKey}-events`;
+    const restoredEvent: HightouchEvent = {
+      type: EventType.TrackEvent,
+      event: 'Restored Purchase',
+      messageId: 'restored-message-id',
+      timestamp: '2010-01-01T00:00:00.000Z',
+      integrations: {},
+    };
+
+    persistor.delayGet(queueKey);
+
+    const client = createClient({
+      writeKey,
+      persistor,
+      flushPolicies: [new StartupFlushPolicy()],
+    });
+
+    await client.init();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    persistor.resolveGet(queueKey, { events: [restoredEvent] });
+    await flushMicrotasks();
+
+    expectUploadedEvent(fetchMock, 'Restored Purchase');
+
+    client.cleanup();
+  });
+
+  it('uploads a tracked event when flush() is awaited after track() completes', async () => {
+    const writeKey = 'awaited-flush-key';
+    const persistor = new TestPersistor();
+    const client = createClient({
+      writeKey,
+      persistor,
+      flushPolicies: [],
+    });
+
+    await client.init();
+
+    await client.track('Purchase Completed', { transaction_id: 'txn-1' });
+    await client.flush();
+
+    expectUploadedEvent(fetchMock, 'Purchase Completed');
+
+    client.cleanup();
+  });
+
+  it('uploads a tracked event when flush() is called immediately after track()', async () => {
+    const writeKey = 'flush-after-track-key';
+    const persistor = new TestPersistor();
+    const client = createClient({
+      writeKey,
+      persistor,
+      flushPolicies: [],
+    });
+
+    await client.init();
+
+    // Customer wrapper pattern: fire-and-forget track followed by immediate flush
+    // to "guarantee delivery before the user backgrounds". The track() promise is
+    // intentionally not awaited because the wrapper is synchronous.
+    void client.track('Purchase Completed', { transaction_id: 'txn-1' });
+    void client.flush();
+
+    await flushMicrotasks(50);
+
+    expectUploadedEvent(fetchMock, 'Purchase Completed');
+
+    client.cleanup();
+  });
+
+  it('persists a tracked event without an explicit flush', async () => {
+    const writeKey = 'persist-without-flush-key';
+    const persistor = new TestPersistor();
+    const client = createClient({
+      writeKey,
+      persistor,
+      flushPolicies: [],
+    });
+
+    await client.init();
+
+    void client.track('Purchase Completed', { transaction_id: 'txn-1' });
+    await wait(50);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expectPersistedQueuedEvent(persistor, writeKey, 'Purchase Completed');
+
+    client.cleanup();
+  });
+
+  it('keeps a tracked event persisted when upload fails', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('Network request failed'));
+
+    const writeKey = 'persist-after-upload-failure-key';
+    const persistor = new TestPersistor();
+    const client = createClient({
+      writeKey,
+      persistor,
+      flushPolicies: [],
+    });
+
+    await client.init();
+
+    await client.track('Purchase Completed', { transaction_id: 'txn-1' });
+    await client.flush();
+    await wait(50);
+
+    expect(fetchMock).toHaveBeenCalled();
+    expectPersistedQueuedEvent(persistor, writeKey, 'Purchase Completed');
+
+    client.cleanup();
+  });
+
+  it('uploads the event that triggers CountFlushPolicy(1)', async () => {
+    const writeKey = 'count-flush-key';
+    const persistor = new TestPersistor();
+    const client = createClient({
+      writeKey,
+      persistor,
+      flushPolicies: [new CountFlushPolicy(1)],
+    });
+
+    await client.init();
+
+    void client.track('Purchase Completed', { transaction_id: 'txn-1' });
+    await flushMicrotasks(50);
+
+    expectUploadedEvent(fetchMock, 'Purchase Completed');
+
+    client.cleanup();
+  });
+
+  it('uploads events tracked before init completes', async () => {
+    const writeKey = 'pre-ready-count-flush-key';
+    const persistor = new TestPersistor();
+    const client = createClient({
+      writeKey,
+      persistor,
+      flushPolicies: [new CountFlushPolicy(1)],
+    });
+
+    void client.init();
+    void client.track('Purchase Completed', { transaction_id: 'txn-1' });
+
+    await wait(50);
+
+    expectUploadedEvent(fetchMock, 'Purchase Completed');
+
+    client.cleanup();
+  });
+
+  it('uploads pre-ready events when flush() is awaited before init completes', async () => {
+    const writeKey = 'pre-ready-manual-flush-key';
+    const persistor = new TestPersistor();
+    const client = createClient({
+      writeKey,
+      persistor,
+      flushPolicies: [],
+    });
+
+    const initPromise = client.init();
+    void client.track('Purchase Completed', { transaction_id: 'txn-1' });
+
+    await client.flush();
+    await initPromise;
+    await flushMicrotasks(50);
+
+    expectUploadedEvent(fetchMock, 'Purchase Completed');
+
+    client.cleanup();
+  });
+
+  it('does not reject flush when init reports a late replay failure', async () => {
+    const writeKey = 'pre-ready-flush-late-init-failure-key';
+    const persistor = new TestPersistor();
+    const initialPendingEvent: HightouchEvent = {
+      type: EventType.TrackEvent,
+      event: 'Initial Pending Event',
+      messageId: 'initial-pending-message-id',
+      timestamp: '2999-01-01T00:00:00.000Z',
+      integrations: {},
+    };
+    await persistor.set(`${writeKey}-pendingEvents`, [initialPendingEvent]);
+
+    class ThrowingPolicy extends CountFlushPolicy {
+      onEvent(event: HightouchEvent): void {
+        if (
+          event.type === EventType.TrackEvent &&
+          event.event === 'Initial Pending Event'
+        ) {
+          throw new Error('Replay policy failure');
+        }
+        super.onEvent(event);
+      }
+    }
+
+    const client = createClient({
+      writeKey,
+      persistor,
+      flushPolicies: [new ThrowingPolicy(1)],
+    });
+
+    const initPromise = client.init();
+    let initResolved = false;
+    const observedInitPromise = initPromise.then(() => {
+      initResolved = true;
+    });
+
+    await expect(client.flush()).resolves.toBeUndefined();
+    expect(initResolved).toBe(true);
+    await expect(observedInitPromise).resolves.toBeUndefined();
+
+    client.cleanup();
+  });
+
+  it('uploads events tracked during pending-event replay before init completes', async () => {
+    const writeKey = 'pending-replay-track-key';
+    const persistor = new TestPersistor();
+    const initialPendingEvent: HightouchEvent = {
+      type: EventType.TrackEvent,
+      event: 'Initial Pending Event',
+      messageId: 'initial-pending-message-id',
+      timestamp: '2999-01-01T00:00:00.000Z',
+      integrations: {},
+    };
+    await persistor.set(`${writeKey}-pendingEvents`, [initialPendingEvent]);
+
+    class TrackDuringReplayPlugin extends UtilityPlugin {
+      type = PluginType.enrichment;
+
+      execute(event: HightouchEvent): HightouchEvent {
+        if (
+          event.type === EventType.TrackEvent &&
+          event.event === 'Initial Pending Event'
+        ) {
+          void this.analytics?.track('Nested Purchase Completed', {
+            transaction_id: 'txn-nested',
+          });
+        }
+        return event;
+      }
+    }
+
+    const client = createClient({
+      writeKey,
+      persistor,
+      flushPolicies: [new CountFlushPolicy(1)],
+    });
+    client.add({ plugin: new TrackDuringReplayPlugin() });
+
+    await client.init();
+    await flushMicrotasks(50);
+
+    expectUploadedEvent(fetchMock, 'Nested Purchase Completed');
+
+    client.cleanup();
+  });
+
+  it('flush() triggered during pending replay uploads every replayed event', async () => {
+    // Regression: with the old `!isReady && initPromise` guard in flush(),
+    // a flush call that landed after isReady=true but before
+    // processPendingEvents finished would snapshot the destination queue
+    // partway through replay. With no other flush trigger in play (empty
+    // policies), the remaining events would sit in the queue indefinitely.
+    const writeKey = 'flush-during-replay-key';
+    const persistor = new TestPersistor();
+    const persistedEvents: HightouchEvent[] = [
+      {
+        type: EventType.TrackEvent,
+        event: 'Pending 1',
+        messageId: 'pending-1',
+        timestamp: '2999-01-01T00:00:00.000Z',
+        integrations: {},
+      },
+      {
+        type: EventType.TrackEvent,
+        event: 'Pending 2',
+        messageId: 'pending-2',
+        timestamp: '2999-01-01T00:00:00.000Z',
+        integrations: {},
+      },
+      {
+        type: EventType.TrackEvent,
+        event: 'Pending 3',
+        messageId: 'pending-3',
+        timestamp: '2999-01-01T00:00:00.000Z',
+        integrations: {},
+      },
+    ];
+    await persistor.set(`${writeKey}-pendingEvents`, persistedEvents);
+
+    let capturedFlushPromise: Promise<void> | undefined;
+
+    class FlushDuringReplayPlugin extends UtilityPlugin {
+      type = PluginType.enrichment;
+      execute(event: HightouchEvent): HightouchEvent {
+        if (
+          event.type === EventType.TrackEvent &&
+          event.event === 'Pending 1' &&
+          capturedFlushPromise === undefined
+        ) {
+          capturedFlushPromise = this.analytics?.flush();
+        }
+        return event;
+      }
+    }
+
+    const client = createClient({
+      writeKey,
+      persistor,
+      flushPolicies: [],
+    });
+    client.add({ plugin: new FlushDuringReplayPlugin() });
+
+    await client.init();
+    await capturedFlushPromise;
+
+    expectUploadedEvent(fetchMock, 'Pending 1');
+    expectUploadedEvent(fetchMock, 'Pending 2');
+    expectUploadedEvent(fetchMock, 'Pending 3');
+
+    client.cleanup();
+  });
+
+  it('uploads queued events when an active app enters background', async () => {
+    const callbacks: Array<(state: AppStateStatus) => void> = [];
+    jest
+      .spyOn(AppState, 'addEventListener')
+      .mockImplementation(
+        (_event, callback: (state: AppStateStatus) => void) => {
+          callbacks.push(callback);
+          return { remove: jest.fn() };
+        }
+      );
+    AppState.currentState = 'active';
+
+    const writeKey = 'background-key';
+    const persistor = new TestPersistor();
+    const client = createClient({
+      writeKey,
+      persistor,
+      flushPolicies: [new BackgroundFlushPolicy()],
+      trackAppLifecycleEvents: true,
+    });
+
+    await client.init();
+    await client.track('Purchase Completed', { transaction_id: 'txn-1' });
+
+    callbacks.forEach((callback) => callback('background'));
+    await flushMicrotasks();
+
+    expectUploadedEvent(fetchMock, 'Purchase Completed');
+
+    client.cleanup();
+  });
+});

--- a/packages/core/src/__tests__/internal/init.test.ts
+++ b/packages/core/src/__tests__/internal/init.test.ts
@@ -1,10 +1,13 @@
 import { HightouchClient } from '../../analytics';
 import * as context from '../../context';
-import { getMockLogger, MockHightouchStore } from '../../test-helpers';
+import { getMockLogger } from '../../test-helpers/mockLogger';
+import { MockHightouchStore } from '../../test-helpers/mockHightouchStore';
 import { PluginType, Context, EventType } from '../../types';
 import { UtilityPlugin } from '../../plugin';
 
 jest.mock('uuid');
+
+const nowIso = Date.prototype.toISOString.bind(new Date());
 
 const currentContext = {
   app: {
@@ -164,21 +167,22 @@ describe('init() resilience', () => {
       client.cleanup();
     });
 
-    it('continues replaying events when one fails', async () => {
+    it('preserves failed pending events while continuing to replay later events', async () => {
+      const freshTimestamp = nowIso();
       const store = new MockHightouchStore({
         pendingEvents: [
           {
             messageId: 'bad-event',
             type: EventType.TrackEvent,
             event: 'Bad Event',
-            timestamp: '2010-01-01T00:00:00.000Z',
+            timestamp: freshTimestamp,
             integrations: {},
           },
           {
             messageId: 'good-event',
             type: EventType.TrackEvent,
             event: 'Good Event',
-            timestamp: '2010-01-01T00:00:00.000Z',
+            timestamp: freshTimestamp,
             integrations: {},
           },
         ],
@@ -212,7 +216,60 @@ describe('init() resilience', () => {
       expect(client.startTimelineProcessing).toHaveBeenCalledWith(
         expect.objectContaining({ messageId: 'good-event' })
       );
-      expect(store.pendingEvents.get().length).toBe(0);
+      expect(store.pendingEvents.get()).toEqual([
+        expect.objectContaining({ messageId: 'bad-event' }),
+      ]);
+
+      client.cleanup();
+    });
+
+    it('drops pending events older than the max retention window', async () => {
+      const staleTimestamp = new Date(
+        Date.now() - 8 * 24 * 60 * 60 * 1000
+      ).toISOString();
+      const freshTimestamp = nowIso();
+      const store = new MockHightouchStore({
+        pendingEvents: [
+          {
+            messageId: 'stale-event',
+            type: EventType.TrackEvent,
+            event: 'Stale Event',
+            timestamp: staleTimestamp,
+            integrations: {},
+          },
+          {
+            messageId: 'fresh-event',
+            type: EventType.TrackEvent,
+            event: 'Fresh Event',
+            timestamp: freshTimestamp,
+            integrations: {},
+          },
+        ],
+      });
+      const client = new HightouchClient({
+        config: {
+          writeKey: 'test-key',
+          trackAppLifecycleEvents: false,
+          autoAddHightouchDestination: false,
+        },
+        logger: getMockLogger(),
+        store,
+      });
+
+      // @ts-ignore
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client.startTimelineProcessing = jest.fn(async (event: any) => event);
+
+      await client.init();
+
+      // Stale event removed without being replayed; fresh event replayed and removed.
+      expect(store.pendingEvents.get()).toEqual([]);
+      // @ts-ignore
+      expect(client.startTimelineProcessing).toHaveBeenCalledTimes(1);
+      // @ts-ignore
+      expect(client.startTimelineProcessing).toHaveBeenCalledWith(
+        expect.objectContaining({ messageId: 'fresh-event' })
+      );
 
       client.cleanup();
     });

--- a/packages/core/src/__tests__/methods/process.test.ts
+++ b/packages/core/src/__tests__/methods/process.test.ts
@@ -6,7 +6,7 @@ jest.mock('uuid');
 
 jest
   .spyOn(Date.prototype, 'toISOString')
-  .mockReturnValue('2010-01-01T00:00:00.000Z');
+  .mockReturnValue('2999-01-01T00:00:00.000Z');
 
 describe('process', () => {
   const store = new MockHightouchStore({
@@ -68,6 +68,8 @@ describe('process', () => {
     jest.spyOn(client.isReady, 'value', 'get').mockReturnValue(true);
     // @ts-ignore
     await client.onReady();
+    // @ts-ignore
+    await client.processPendingEvents();
     expectedEvent = {
       ...expectedEvent,
       context: { ...store.context.get() },

--- a/packages/core/src/analytics.ts
+++ b/packages/core/src/analytics.ts
@@ -915,9 +915,8 @@ export class HightouchClient {
         );
       }
 
-      // Only layer on the lifecycle defaults if the caller hasn't explicitly
-      // disabled both Count and Timer — otherwise they've opted out of
-      // auto-flush and we shouldn't sneak flushes back in via lifecycle hooks.
+      // If the caller explicitly disables both flushAt and flushInterval (e.g. set both to 0),
+      // we treat that as an opt-out of auto-flush entirely and skip the lifecycle defaults too.
       if (flushPolicies.length > 0) {
         flushPolicies.push(new StartupFlushPolicy());
         flushPolicies.push(new BackgroundFlushPolicy());

--- a/packages/core/src/analytics.ts
+++ b/packages/core/src/analytics.ts
@@ -885,6 +885,9 @@ export class HightouchClient {
    *   - TimerFlushPolicy(flushInterval ?? defaultFlushInterval) for idle flushing
    *   - StartupFlushPolicy() to re-deliver events persisted from a prior session
    *   - BackgroundFlushPolicy() to flush before the OS suspends the app
+   *
+   * If the caller explicitly disables both flushAt and flushInterval (e.g. set both to 0),
+   * we treat that as an opt-out of auto-flush entirely and skip the lifecycle defaults too.
    */
   private setupFlushPolicies() {
     const flushPolicies: FlushPolicy[] = [];
@@ -912,8 +915,13 @@ export class HightouchClient {
         );
       }
 
-      flushPolicies.push(new StartupFlushPolicy());
-      flushPolicies.push(new BackgroundFlushPolicy());
+      // Only layer on the lifecycle defaults if the caller hasn't explicitly
+      // disabled both Count and Timer — otherwise they've opted out of
+      // auto-flush and we shouldn't sneak flushes back in via lifecycle hooks.
+      if (flushPolicies.length > 0) {
+        flushPolicies.push(new StartupFlushPolicy());
+        flushPolicies.push(new BackgroundFlushPolicy());
+      }
     }
 
     this.flushPolicyExecuter = new FlushPolicyExecuter(flushPolicies, () => {

--- a/packages/core/src/analytics.ts
+++ b/packages/core/src/analytics.ts
@@ -7,6 +7,7 @@ import {
 import {
   defaultFlushInterval,
   defaultFlushAt,
+  MAX_PENDING_EVENT_AGE_MS,
   STORAGE_READY_TIMEOUT_MS,
 } from './constants';
 import { getContext } from './context';
@@ -18,8 +19,10 @@ import {
   createTrackEvent,
 } from './events';
 import {
+  BackgroundFlushPolicy,
   CountFlushPolicy,
   Observable,
+  StartupFlushPolicy,
   TimerFlushPolicy,
 } from './flushPolicies';
 import { FlushPolicyExecuter } from './flushPolicies/flush-policy-executer';
@@ -81,11 +84,19 @@ export class HightouchClient {
   private storageReadyTimeoutId?: ReturnType<typeof setTimeout>;
   private storageReadyUnsubscribe?: () => void;
 
+  private initPromise?: Promise<void>;
+
   private isAddingPlugins = false;
 
   private timeline: Timeline;
 
   private pluginsToAdd: Plugin[] = [];
+
+  // Number of active process() calls to allow draining the queue before flushing.
+  // Otherwise `void track(...); void flush();` would snapshot the queue before the track has dispatched.
+  // Same for CountFlushPolicy() on the final event.
+  private inFlightProcessCount = 0;
+  private inFlightProcessObservers: Array<() => void> = [];
 
   private flushPolicyExecuter!: FlushPolicyExecuter;
 
@@ -143,15 +154,13 @@ export class HightouchClient {
     if (ofType !== undefined) {
       return [...(plugins[ofType] ?? [])];
     }
-    return (
-      [
-        ...this.getPlugins(PluginType.before),
-        ...this.getPlugins(PluginType.enrichment),
-        ...this.getPlugins(PluginType.utility),
-        ...this.getPlugins(PluginType.destination),
-        ...this.getPlugins(PluginType.after),
-      ] ?? []
-    );
+    return [
+      ...this.getPlugins(PluginType.before),
+      ...this.getPlugins(PluginType.enrichment),
+      ...this.getPlugins(PluginType.utility),
+      ...this.getPlugins(PluginType.destination),
+      ...this.getPlugins(PluginType.after),
+    ];
   }
 
   /**
@@ -270,9 +279,18 @@ export class HightouchClient {
 
   /**
    * Initializes the client plugins, settings and subscribers.
-   * Can only be called once.
+   * Multiple calls to init() are ignored and return the same promise.
    */
-  async init() {
+  async init(): Promise<void> {
+    if (this.initPromise !== undefined) {
+      return this.initPromise;
+    }
+
+    this.initPromise = this.runInit();
+    return this.initPromise;
+  }
+
+  private async runInit(): Promise<void> {
     if (this.isReady.value) {
       this.logger.warn('HightouchClient already initialized');
       return;
@@ -321,8 +339,20 @@ export class HightouchClient {
       );
     }
 
-    this.isReady.value = true;
-    this.flushPolicyExecuter.manualFlush();
+    try {
+      this.isReady.value = true;
+      await this.waitForInFlightProcesses();
+      await this.processPendingEvents();
+      this.flushPolicyExecuter.manualFlush();
+    } catch (error) {
+      this.reportInternalError(
+        new HightouchError(
+          ErrorType.InitializationError,
+          'post-ready init failed, continuing without throwing',
+          error
+        )
+      );
+    }
   }
 
   /*
@@ -473,14 +503,48 @@ export class HightouchClient {
   }
 
   async process(incomingEvent: HightouchEvent) {
-    const event = this.applyRawEventData(incomingEvent);
+    return this.runProcess(async () => {
+      const event = this.applyRawEventData(incomingEvent);
 
-    if (this.isReady.value) {
-      return this.startTimelineProcessing(event);
-    } else {
-      this.store.pendingEvents.add(event);
-      return event;
+      if (this.isReady.value) {
+        return await this.startTimelineProcessing(event);
+      } else {
+        await this.store.pendingEvents.add(event);
+        return event;
+      }
+    });
+  }
+
+  /**
+   * Processes a work item while tracking it as in-flight, so a concurrent
+   * flush() can wait for the dispatch to land in the queue before snapshotting.
+   * This is to handle sequences like `void track(...); void flush();` which would otherwise
+   * snapshot the queue before the track has been added to it, making the flush a no-op.
+   */
+  private async runProcess<T>(work: () => Promise<T>): Promise<T> {
+    this.inFlightProcessCount++;
+    try {
+      return await work();
+    } finally {
+      this.inFlightProcessCount--;
+      if (this.inFlightProcessCount === 0) {
+        const observers = this.inFlightProcessObservers;
+        this.inFlightProcessObservers = [];
+        observers.forEach((notify) => notify());
+      }
     }
+  }
+
+  /**
+   * Resolves once there are no in-flight process() calls.
+   */
+  private waitForInFlightProcesses(): Promise<void> {
+    if (this.inFlightProcessCount === 0) {
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      this.inFlightProcessObservers.push(resolve);
+    });
   }
 
   /**
@@ -547,11 +611,25 @@ export class HightouchClient {
         this.isAddingPlugins = false;
       }
     }
+  }
 
+  private async processPendingEvents() {
     const pending = await this.store.pendingEvents.get(true);
     for (const e of pending) {
+      if (
+        e.timestamp !== undefined &&
+        Date.now() - Date.parse(e.timestamp) > MAX_PENDING_EVENT_AGE_MS
+      ) {
+        // Past the API's accepted age window; drop instead of retrying forever.
+        await this.store.pendingEvents.remove(e);
+        continue;
+      }
       try {
-        await this.startTimelineProcessing(e);
+        await this.runProcess(() => this.startTimelineProcessing(e));
+        // Only remove the event from durable storage on successful replay.
+        // If replay throws, the event stays in pendingEvents so a future
+        // session has a chance to deliver it.
+        await this.store.pendingEvents.remove(e);
       } catch (error) {
         this.reportInternalError(
           new HightouchError(
@@ -561,7 +639,6 @@ export class HightouchClient {
           )
         );
       }
-      await this.store.pendingEvents.remove(e);
     }
   }
 
@@ -570,6 +647,18 @@ export class HightouchClient {
       if (this.destroyed) {
         return;
       }
+
+      // Wait for init to fully complete (including pending-event replay) before snapshotting.
+      // Otherwise customers that send events on startup without awaiting the init might see a stale queue snapshot.
+      if (this.initPromise !== undefined) {
+        await this.initPromise;
+      }
+
+      // Wait for any in-flight process() calls so their events land in the
+      // destination queue before we snapshot it. Without this, a caller that
+      // fires track() and immediately flushes (without awaiting track) would
+      // see the flush snapshot the queue before the track has dispatched.
+      await this.waitForInFlightProcesses();
 
       this.flushPolicyExecuter.reset();
 
@@ -789,13 +878,17 @@ export class HightouchClient {
   }
 
   /**
-   * Initializes the flush policies from config and subscribes to updates to
-   * trigger flush
+   * Initializes the flush policies from config and subscribes to updates to trigger flush.
+   *
+   * When the caller does not supply an explicit `flushPolicies` array, we apply:
+   *   - CountFlushPolicy(flushAt ?? defaultFlushAt) for in-session batching
+   *   - TimerFlushPolicy(flushInterval ?? defaultFlushInterval) for idle flushing
+   *   - StartupFlushPolicy() to re-deliver events persisted from a prior session
+   *   - BackgroundFlushPolicy() to flush before the OS suspends the app
    */
   private setupFlushPolicies() {
-    const flushPolicies = [];
+    const flushPolicies: FlushPolicy[] = [];
 
-    // If there are zero policies or flushAt/flushInterval use the defaults:
     if (this.config.flushPolicies !== undefined) {
       flushPolicies.push(...this.config.flushPolicies);
     } else {
@@ -818,6 +911,9 @@ export class HightouchClient {
           )
         );
       }
+
+      flushPolicies.push(new StartupFlushPolicy());
+      flushPolicies.push(new BackgroundFlushPolicy());
     }
 
     this.flushPolicyExecuter = new FlushPolicyExecuter(flushPolicies, () => {

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -18,6 +18,10 @@ export const uploadEvents = async ({
   try {
     return await fetch(url, {
       method: 'POST',
+      // In theory, keepalive lets the runtime finish the request even if the app backgrounds.
+      // In practice, react-native's fetch implementation does not support keepalive.
+      // Doesn't hurt though in case that changes.
+      keepalive: true,
       body: JSON.stringify({
         batch: events,
         sentAt: new Date().toISOString(),

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -15,3 +15,7 @@ export const defaultFlushAt = 20;
 export const defaultFlushInterval = 30;
 
 export const STORAGE_READY_TIMEOUT_MS = 5_000;
+
+// The events API rejects events older than 7 days, so a persisted pending
+// event past that point can never be delivered and should be dropped on replay.
+export const MAX_PENDING_EVENT_AGE_MS = 7 * 24 * 60 * 60 * 1000;

--- a/packages/core/src/flushPolicies/__tests__/background-flush-policy.test.ts
+++ b/packages/core/src/flushPolicies/__tests__/background-flush-policy.test.ts
@@ -1,35 +1,74 @@
 import { AppState, AppStateStatus } from 'react-native';
 import { BackgroundFlushPolicy } from '../background-flush-policy';
 
+function setupPolicy(initialAppState: AppStateStatus = 'active') {
+  AppState.currentState = initialAppState;
+  let updateCallback = (_val: AppStateStatus) => {
+    return;
+  };
+  const addSpy = jest
+    .spyOn(AppState, 'addEventListener')
+    .mockImplementation((_action, callback) => {
+      updateCallback = callback;
+      return { remove: jest.fn() };
+    });
+
+  const policy = new BackgroundFlushPolicy();
+  policy.start();
+  const observer = jest.fn();
+  policy.shouldFlush.onChange(observer);
+
+  return {
+    addSpy,
+    policy,
+    observer,
+    transitionTo: (state: AppStateStatus) => updateCallback(state),
+  };
+}
+
 describe('BackgroundFlushPolicy', () => {
-  it('triggers a flush when reaching limit', () => {
-    let updateCallback = (_val: AppStateStatus) => {
-      return;
-    };
-
-    const addSpy = jest
-      .spyOn(AppState, 'addEventListener')
-      .mockImplementation((_action, callback) => {
-        updateCallback = callback;
-        return { remove: jest.fn() };
-      });
-
-    const policy = new BackgroundFlushPolicy();
-    policy.start();
-    const observer = jest.fn();
-
-    policy.shouldFlush.onChange(observer);
+  it('flushes when an active app transitions to background', () => {
+    const { addSpy, observer, transitionTo } = setupPolicy('active');
 
     expect(addSpy).toHaveBeenCalledTimes(1);
 
-    updateCallback('background');
+    transitionTo('background');
     expect(observer).toHaveBeenCalledWith(true);
+  });
+
+  it('flushes when an active app transitions to inactive', () => {
+    const { observer, transitionTo } = setupPolicy('active');
+
+    transitionTo('inactive');
+    expect(observer).toHaveBeenCalledWith(true);
+  });
+
+  it('does not flush when transitioning back to active', () => {
+    const { observer, transitionTo } = setupPolicy('active');
+
+    transitionTo('background');
     observer.mockClear();
 
-    updateCallback('active');
+    transitionTo('active');
+    expect(observer).not.toHaveBeenCalled();
+  });
+
+  it('flushes after the next active→background even when constructed before AppState settled', () => {
+    const { observer, transitionTo } = setupPolicy('unknown' as AppStateStatus);
+
+    transitionTo('active');
     expect(observer).not.toHaveBeenCalled();
 
-    updateCallback('inactive');
+    transitionTo('background');
     expect(observer).toHaveBeenCalledWith(true);
+  });
+
+  it('does not double-fire on active→inactive→background', () => {
+    const { observer, transitionTo } = setupPolicy('active');
+
+    transitionTo('inactive');
+    transitionTo('background');
+
+    expect(observer.mock.calls).toEqual([[true]]);
   });
 });

--- a/packages/core/src/flushPolicies/background-flush-policy.ts
+++ b/packages/core/src/flushPolicies/background-flush-policy.ts
@@ -6,33 +6,43 @@ import {
 import type { HightouchEvent } from '../types';
 import { FlushPolicyBase } from './types';
 
+const INACTIVE_STATES: ReadonlyArray<AppStateStatus> = [
+  'inactive',
+  'background',
+];
+
 /**
- * StatupFlushPolicy triggers a flush right away on client startup
+ * BackgroundFlushPolicy triggers a flush whenever the app moves from a foreground state to a background state.
  */
 export class BackgroundFlushPolicy extends FlushPolicyBase {
   private appStateSubscription?: NativeEventSubscription;
-  private appState: AppStateStatus = AppState.currentState;
+  private lastState: AppStateStatus = AppState.currentState;
 
   start() {
     this.appStateSubscription = AppState.addEventListener(
       'change',
-      (nextAppState) => {
-        if (
-          this.appState === 'active' &&
-          ['inactive', 'background'].includes(nextAppState)
-        ) {
-          // When the app goes into the background we will trigger a flush
-          this.shouldFlush.value = true;
-        }
-      }
+      this.handleAppStateChange
     );
   }
 
   onEvent(_event: HightouchEvent): void {
-    // Nothing to do
+    // Nothing to do — this policy is driven by AppState transitions, not events.
   }
 
   end(): void {
     this.appStateSubscription?.remove();
+    this.appStateSubscription = undefined;
   }
+
+  private handleAppStateChange = (nextState: AppStateStatus): void => {
+    const previousState = this.lastState;
+    this.lastState = nextState;
+
+    if (
+      !INACTIVE_STATES.includes(previousState) &&
+      INACTIVE_STATES.includes(nextState)
+    ) {
+      this.shouldFlush.value = true;
+    }
+  };
 }

--- a/packages/core/src/flushPolicies/startup-flush-policy.ts
+++ b/packages/core/src/flushPolicies/startup-flush-policy.ts
@@ -2,7 +2,7 @@ import type { HightouchEvent } from '../types';
 import { FlushPolicyBase } from './types';
 
 /**
- * StatupFlushPolicy triggers a flush right away on client startup
+ * StartupFlushPolicy triggers a flush right away on client startup
  */
 export class StartupFlushPolicy extends FlushPolicyBase {
   start() {

--- a/packages/core/src/plugins/QueueFlushingPlugin.ts
+++ b/packages/core/src/plugins/QueueFlushingPlugin.ts
@@ -1,8 +1,53 @@
 import { createStore, Store } from '@ht-sdks/sovran-react-native';
 import type { HightouchClient } from '../analytics';
 import { defaultConfig } from '../constants';
+import { ErrorType, HightouchError } from '../errors';
 import { UtilityPlugin } from '../plugin';
 import { PluginType, HightouchEvent } from '../types';
+
+const DEFAULT_RESTORE_TIMEOUT_MS = 1000;
+
+/** A one-shot readiness signal you can wait on, with an optional timeout. */
+class ReadySignal {
+  private readonly opened: Promise<void>;
+  private resolveOpened!: () => void;
+  private errorReported = false;
+
+  constructor(timeoutMs?: number) {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    this.opened = new Promise<void>((resolve, reject) => {
+      this.resolveOpened = () => {
+        if (timeoutId !== undefined) clearTimeout(timeoutId);
+        resolve();
+      };
+      if (timeoutMs !== undefined) {
+        timeoutId = setTimeout(
+          () => reject(new Error(`ReadySignal timed out after ${timeoutMs}ms`)),
+          timeoutMs
+        );
+      }
+    });
+    // Swallow unhandled-rejection from the timeout; wait() observes it.
+    this.opened.catch(() => {});
+  }
+
+  /** Marks the signal as ready, releasing all current and future waiters. */
+  open(): void {
+    this.resolveOpened();
+  }
+
+  /** Resolves when opened, or runs onError (at most once) if the timeout fires first. */
+  async wait(onError?: (e: unknown) => void): Promise<void> {
+    try {
+      await this.opened;
+    } catch (e) {
+      if (onError !== undefined && !this.errorReported) {
+        this.errorReported = true;
+        onError(e);
+      }
+    }
+  }
+}
 
 /**
  * This plugin manages a queue where all events get added to after timeline processing.
@@ -14,12 +59,25 @@ export class QueueFlushingPlugin extends UtilityPlugin {
   type = PluginType.after;
 
   private storeKey: string;
-  private isPendingUpload = false;
   private queueStore: Store<{ events: HightouchEvent[] }> | undefined;
   private onFlush: (events: HightouchEvent[]) => Promise<void>;
 
   /**
+   * Signaled once sovran has hydrated the queue from persistence, or fails after a timeout.
+   * flush() waits on this so we don't upload an empty queue while the previous session's events are still loading.
+   */
+  private readonly restored: ReadySignal;
+
+  /**
+   * Tracks the in-flight flush, if any, so overlapping flush() calls attach to it instead of starting a parallel upload.
+   * Note that this technically does mean overlapping flushes won't re-snapshot the queue,
+   * but we're choosing to accept that rather than risking performance hits on the caller.
+   */
+  private flushPromise?: Promise<void>;
+
+  /**
    * @param onFlush callback to execute when the queue is flushed (either by reaching the limit or manually) e.g. code to upload events to your destination
+   * @param storeKey persistence key suffix; must be unique to avoid AsyncStorage collisions
    */
   constructor(
     onFlush: (events: HightouchEvent[]) => Promise<void>,
@@ -28,6 +86,7 @@ export class QueueFlushingPlugin extends UtilityPlugin {
     super();
     this.onFlush = onFlush;
     this.storeKey = storeKey;
+    this.restored = new ReadySignal(DEFAULT_RESTORE_TIMEOUT_MS);
   }
 
   configure(analytics: HightouchClient): void {
@@ -43,6 +102,9 @@ export class QueueFlushingPlugin extends UtilityPlugin {
           storeId: `${config.writeKey}-${this.storeKey}`,
           persistor: config.storePersistor,
           saveDelay: config.storePersistorSaveDelay ?? 0,
+          onInitialized: () => {
+            this.restored.open();
+          },
         },
       }
     );
@@ -57,18 +119,39 @@ export class QueueFlushingPlugin extends UtilityPlugin {
   }
 
   /**
-   * Calls the onFlush callback with the events in the queue
+   * Calls the onFlush callback with the events in the queue.
+   *
+   * Concurrent callers share a single in-flight upload.
+   * This means in rare scenarios where overlapping flushes are occurring,
+   * an event coming in between the two flushes may not be finished by the time the flush resolves.
    */
-  async flush() {
-    const events = (await this.queueStore?.getState(true))?.events ?? [];
-    if (!this.isPendingUpload) {
-      try {
-        this.isPendingUpload = true;
-        await this.onFlush(events);
-      } finally {
-        this.isPendingUpload = false;
-      }
+  async flush(): Promise<void> {
+    if (this.flushPromise !== undefined) {
+      await this.flushPromise;
+      return;
     }
+
+    this.flushPromise = this.runFlush();
+    try {
+      await this.flushPromise;
+    } finally {
+      this.flushPromise = undefined;
+    }
+  }
+
+  private async runFlush(): Promise<void> {
+    await this.restored.wait((e) =>
+      this.analytics?.reportInternalError(
+        new HightouchError(
+          ErrorType.InitializationError,
+          'Queue restoration did not complete before timeout; flushing with in-memory state',
+          e
+        )
+      )
+    );
+
+    const events = (await this.queueStore?.getState(true))?.events ?? [];
+    await this.onFlush(events);
   }
 
   /**
@@ -83,9 +166,7 @@ export class QueueFlushingPlugin extends UtilityPlugin {
         return state;
       }
 
-      const idsToRemove = new Set(
-        eventsToRemove.map((e) => e.messageId)
-      );
+      const idsToRemove = new Set(eventsToRemove.map((e) => e.messageId));
       const filteredEvents = state.events.filter(
         (e) => !idsToRemove.has(e.messageId)
       );

--- a/packages/core/src/plugins/QueueFlushingPlugin.ts
+++ b/packages/core/src/plugins/QueueFlushingPlugin.ts
@@ -7,46 +7,62 @@ import { PluginType, HightouchEvent } from '../types';
 
 const DEFAULT_RESTORE_TIMEOUT_MS = 1000;
 
-/** A one-shot readiness signal you can wait on, with an optional timeout. */
+/** A one-shot readiness signal you can wait on, with a timeout. */
 class ReadySignal {
   private readonly opened: Promise<void>;
   private resolveOpened!: () => void;
-  private errorReported = false;
+  private isOpen = false;
+  private timeoutPromise?: Promise<void>;
+  private timeoutId?: ReturnType<typeof setTimeout>;
+  private timeoutReported = false;
 
-  constructor(timeoutMs?: number) {
-    let timeoutId: ReturnType<typeof setTimeout> | undefined;
-    this.opened = new Promise<void>((resolve, reject) => {
-      this.resolveOpened = () => {
-        if (timeoutId !== undefined) {
-          clearTimeout(timeoutId);
-        }
-        resolve();
-      };
-      if (timeoutMs !== undefined) {
-        timeoutId = setTimeout(
-          () => reject(new Error(`ReadySignal timed out after ${timeoutMs}ms`)),
-          timeoutMs
-        );
-      }
+  constructor(private readonly timeoutMs: number) {
+    this.opened = new Promise<void>((resolve) => {
+      this.resolveOpened = resolve;
     });
-    // Swallow unhandled-rejection from the timeout; wait() observes it.
-    this.opened.catch(() => undefined);
   }
 
   /** Marks the signal as ready, releasing all current and future waiters. */
   open(): void {
+    if (this.isOpen) {
+      return;
+    }
+    this.isOpen = true;
+    if (this.timeoutId !== undefined) {
+      clearTimeout(this.timeoutId);
+      this.timeoutId = undefined;
+    }
     this.resolveOpened();
   }
 
-  /** Resolves when opened, or runs onError (at most once) if the timeout fires first. */
-  async wait(onError?: (e: unknown) => void): Promise<void> {
+  /**
+   * Resolves when opened, or when the timeout fires.
+   * Invokes onTimeout (at most once across all waiters) if the timeout wins.
+   * Errors thrown by onTimeout are swallowed; wait() never rejects.
+   */
+  async wait(onTimeout?: (e: Error) => void): Promise<void> {
+    if (this.isOpen) {
+      return;
+    }
+
+    this.timeoutPromise ??= new Promise<void>((resolve) => {
+      this.timeoutId = setTimeout(() => {
+        this.timeoutId = undefined;
+        resolve();
+      }, this.timeoutMs);
+    });
+
+    await Promise.race([this.opened, this.timeoutPromise]);
+
+    if (this.isOpen || this.timeoutReported) {
+      return;
+    }
+
+    this.timeoutReported = true;
     try {
-      await this.opened;
-    } catch (e) {
-      if (onError !== undefined && !this.errorReported) {
-        this.errorReported = true;
-        onError(e);
-      }
+      onTimeout?.(new Error(`ReadySignal timed out after ${this.timeoutMs}ms`));
+    } catch {
+      // best-effort: don't let timeout reporting fail the wait
     }
   }
 }

--- a/packages/core/src/plugins/QueueFlushingPlugin.ts
+++ b/packages/core/src/plugins/QueueFlushingPlugin.ts
@@ -17,7 +17,9 @@ class ReadySignal {
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
     this.opened = new Promise<void>((resolve, reject) => {
       this.resolveOpened = () => {
-        if (timeoutId !== undefined) clearTimeout(timeoutId);
+        if (timeoutId !== undefined) {
+          clearTimeout(timeoutId);
+        }
         resolve();
       };
       if (timeoutMs !== undefined) {
@@ -28,7 +30,7 @@ class ReadySignal {
       }
     });
     // Swallow unhandled-rejection from the timeout; wait() observes it.
-    this.opened.catch(() => {});
+    this.opened.catch(() => undefined);
   }
 
   /** Marks the signal as ready, releasing all current and future waiters. */


### PR DESCRIPTION
This PR makes a few attempts at improving reliability. While most of these wouldn't result in _immediately_ dropping events, they would potentially result in events not being sent until the next time the app is opened. If that happens after 7 days, then events would be stale and we would drop the events server-side. I would expect this to be especially impactful for marketplace/store apps, where an important purchase event might get dropped if not flushed by the time the user backgrounds the app, given that the user used the app for a specific purpose and may not re-open the app for some time.

The changes:
- Default to including StartupFlush and BackgroundFlush policies, and show them in the sample app. Otherwise count/timer policies are likely to not fire by the time a user backgrounds the app after making a purchase or similar event.
- Fix the scenario where `void track(); await/void flush()` would not flush the track because it hasn't entered the queue by the time `flush` is called. This is a common pattern, but more importantly applies to scenarios like the CountFlush policy. The final event that triggered the flush was not part of that snapshot, therefore flush completes before that event is sent off, and it has to wait for the next flush instead. This is especially impactful with CountFlush(1).
- Events that were created while we were handling pending events on startup would be added to `pendingEvents` rather than being treated as events in the session. This means they wouldn't be sent until the next startup. Now they'll be treated as regular events and sent when the next flush occurs.
- BackgroundFlushPolicy could be a no-op if the initial state was not an active state. I'm not certain how likely this is in practice, but worth fixing.
- Wait for the persisted destination queue to restore before startup flush reads it. Without this, `StartupFlushPolicy` could fire against an empty in-memory queue while events from the previous session were still being restored from storage.

Compromises:
- Calling `flush` while another concurrent flush is already happening was potentially a no-op previously. Now we return the existing flush promise instead. This is a compromise though -- ideally we'd actually return `flushPromise.then(() => flush())` so that we send a flush that has the events between the previous flush and the current one snapshotted. I'm worried about that having a performance impact on the caller though, so the compromise is at least waiting for the existing flush to occur. Open to suggestions here, it might be worth scheduling another flush.
- We still don't have native background uploader support. If we start a `fetch` and get backgrounded, the OS may choose to cancel our call. In this case we'd have to wait until the app is launched again before we can send the queued event off.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Startup/background auto-flush is added when auto-flush is enabled.
  * Persisted pending events older than 7 days are dropped.

* **Bug Fixes**
  * Initialization is concurrency-safe and idempotent.
  * Flush now waits for pending-event replay and in-flight processing.
  * Improved background/inactive transition detection for timely uploads.
  * Event uploads include keepalive where supported.
  * Queue flushing now coordinates restoration and shares concurrent flushes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ht-sdks/events-sdk-react-native/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->