### PR TITLE
fix(ci): trust wix/brew tap before installing applesimutils

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Install applesimutils
         run: |
           HOMEBREW_NO_AUTO_UPDATE=1 brew tap wix/brew >/dev/null
+          HOMEBREW_NO_AUTO_UPDATE=1 brew trust wix/brew
           HOMEBREW_NO_AUTO_UPDATE=1 brew install applesimutils >/dev/null
 
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Summary

- Add `brew trust wix/brew` before installing `applesimutils` in the iOS E2E CI job.

## Context

Homebrew on macOS CI runners now refuses to install formulas from untrusted taps without an explicit trust step, causing `run-e2e-ios` to fail with:

```
Refusing to load formula wix/brew/applesimutils from untrusted tap wix/brew.
```

## Test plan

- [x] CI: `run-e2e-ios` passes

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the iOS E2E CI setup to trust the Homebrew source before installing required simulator utilities, improving reliability of the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->