### PR TITLE
feat: add optional per-call context to event methods

### DIFF
--- a/packages/core/src/__tests__/events.test.ts
+++ b/packages/core/src/__tests__/events.test.ts
@@ -51,6 +51,33 @@ describe('#createTrackEvent', () => {
     });
   });
 
+  it('creates a track event with optional context', () => {
+    const event = createTrackEvent({
+      event: 'Awesome event',
+      properties: {
+        foo: 'bar',
+      },
+      context: {
+        protocols: {
+          schemaVersion: 'v1',
+        },
+      },
+    });
+
+    expect(event).toEqual({
+      type: EventType.TrackEvent,
+      event: 'Awesome event',
+      properties: {
+        foo: 'bar',
+      },
+      context: {
+        protocols: {
+          schemaVersion: 'v1',
+        },
+      },
+    });
+  });
+
   it('adds the user id when it exists', () => {
     const event = createTrackEvent({
       event: 'Awesome event',

--- a/packages/core/src/__tests__/methods/alias.test.ts
+++ b/packages/core/src/__tests__/methods/alias.test.ts
@@ -13,7 +13,7 @@ describe('methods #alias', () => {
     userId: 'current-user-id',
   };
 
-  const { store, client, expectEvent } = createTestClient({
+  const { store, client, plugin, expectEvent } = createTestClient({
     userInfo: initialUserInfo,
   });
 
@@ -85,5 +85,35 @@ describe('methods #alias', () => {
       ...initialUserInfo,
       userId: 'new-user-id',
     });
+  });
+
+  it('does not swap per-call context across overlapping alias calls', async () => {
+    const aliasA = client.alias('user-a', {
+      protocols: { schemaVersion: 'v1' },
+    });
+    const aliasB = client.alias('user-b', {
+      protocols: { schemaVersion: 'v2' },
+    });
+    await Promise.all([aliasA, aliasB]);
+
+    const aliasEvents = (plugin.execute as jest.Mock).mock.calls
+      .map(([event]: [HightouchEvent]) => event)
+      .filter((event) => event.type === EventType.AliasEvent);
+
+    expect(aliasEvents).toHaveLength(2);
+    expect(
+      aliasEvents.find((event) => event.userId === 'user-a')?.context
+    ).toEqual(
+      expect.objectContaining({
+        protocols: { schemaVersion: 'v1' },
+      })
+    );
+    expect(
+      aliasEvents.find((event) => event.userId === 'user-b')?.context
+    ).toEqual(
+      expect.objectContaining({
+        protocols: { schemaVersion: 'v2' },
+      })
+    );
   });
 });

--- a/packages/core/src/__tests__/methods/group.test.ts
+++ b/packages/core/src/__tests__/methods/group.test.ts
@@ -44,5 +44,32 @@ describe('methods #group', () => {
 
     expect(client.process).toHaveBeenCalledTimes(1);
     expect(client.process).toHaveBeenCalledWith(expectedEvent);
+    expect(
+      (client.process as jest.Mock).mock.calls[0][0].context
+    ).toBeUndefined();
+  });
+
+  it('stamps per-call context onto the group event', async () => {
+    const client = new HightouchClient(clientArgs);
+    jest.spyOn(client, 'process');
+
+    await client.group(
+      'new-group-id',
+      { name: 'Best Group Ever' },
+      { protocols: { schemaVersion: 'v1' } }
+    );
+
+    expect(client.process).toHaveBeenCalledWith({
+      groupId: 'new-group-id',
+      type: 'group',
+      traits: {
+        name: 'Best Group Ever',
+      },
+      context: {
+        protocols: {
+          schemaVersion: 'v1',
+        },
+      },
+    });
   });
 });

--- a/packages/core/src/__tests__/methods/identify.test.ts
+++ b/packages/core/src/__tests__/methods/identify.test.ts
@@ -129,4 +129,24 @@ describe('methods #identify', () => {
       userId: 'new-user-id',
     });
   });
+
+  it('stamps per-call context onto the identify event', async () => {
+    await client.identify(
+      'new-user-id',
+      { name: 'Mary', age: 30 },
+      { protocols: { schemaVersion: 'v1' } }
+    );
+
+    expectEvent({
+      traits: {
+        name: 'Mary',
+        age: 30,
+      },
+      userId: 'new-user-id',
+      type: EventType.IdentifyEvent,
+      context: expect.objectContaining({
+        protocols: { schemaVersion: 'v1' },
+      }),
+    });
+  });
 });

--- a/packages/core/src/__tests__/methods/process.test.ts
+++ b/packages/core/src/__tests__/methods/process.test.ts
@@ -85,6 +85,49 @@ describe('process', () => {
     );
   });
 
+  it('preserves per-call context when replaying pending events', async () => {
+    const client = new HightouchClient(clientArgs);
+    jest.spyOn(client.isReady, 'value', 'get').mockReturnValue(false);
+    // @ts-ignore
+    const timeline = client.timeline;
+    jest.spyOn(timeline, 'process');
+
+    await client.track(
+      'Some Event',
+      { id: 1 },
+      { protocols: { schemaVersion: 'v1' } }
+    );
+
+    // @ts-ignore
+    const pendingEvent = client.store.pendingEvents.get()[0];
+    expect(pendingEvent).toEqual(
+      expect.objectContaining({
+        event: 'Some Event',
+        properties: { id: 1 },
+        context: {
+          protocols: { schemaVersion: 'v1' },
+        },
+      })
+    );
+
+    jest.spyOn(client.isReady, 'value', 'get').mockReturnValue(true);
+    // @ts-ignore
+    await client.onReady();
+    // @ts-ignore
+    await client.processPendingEvents();
+
+    expect(timeline.process).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'Some Event',
+        properties: { id: 1 },
+        context: {
+          ...store.context.get(),
+          protocols: { schemaVersion: 'v1' },
+        },
+      })
+    );
+  });
+
   it('stamps all context and userInfo data for events when ready', async () => {
     const client = new HightouchClient(clientArgs);
     jest.spyOn(client.isReady, 'value', 'get').mockReturnValue(true);
@@ -112,6 +155,93 @@ describe('process', () => {
 
     expect(timeline.process).toHaveBeenCalledWith(
       expect.objectContaining(expectedEvent)
+    );
+    expect(
+      (timeline.process as jest.Mock).mock.calls[0][0].context
+    ).not.toHaveProperty('protocols');
+  });
+
+  it('deep-merges per-call context onto the processed event context', async () => {
+    const client = new HightouchClient(clientArgs);
+    jest.spyOn(client.isReady, 'value', 'get').mockReturnValue(true);
+
+    // @ts-ignore
+    const timeline = client.timeline;
+    jest.spyOn(timeline, 'process');
+
+    await client.track(
+      'Some Event',
+      { id: 1 },
+      { protocols: { schemaVersion: 'v1' } }
+    );
+
+    expect(timeline.process).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'Some Event',
+        properties: {
+          id: 1,
+        },
+        type: EventType.TrackEvent,
+        context: {
+          ...store.context.get(),
+          protocols: {
+            schemaVersion: 'v1',
+          },
+        },
+        userId: store.userInfo.get().userId,
+        anonymousId: store.userInfo.get().anonymousId,
+      })
+    );
+  });
+
+  it('merges nested per-call context maps next to existing context', async () => {
+    const nestedStore = new MockHightouchStore({
+      userInfo: {
+        userId: 'current-user-id',
+        anonymousId: 'very-anonymous',
+      },
+      context: {
+        library: {
+          name: 'test',
+          version: '1.0',
+        },
+        protocols: {
+          existing: true,
+        },
+      },
+    });
+    const client = new HightouchClient({
+      ...clientArgs,
+      store: nestedStore,
+    });
+    jest.spyOn(client.isReady, 'value', 'get').mockReturnValue(true);
+
+    // @ts-ignore
+    const timeline = client.timeline;
+    jest.spyOn(timeline, 'process');
+
+    await client.track(
+      'Some Event',
+      { id: 1 },
+      { protocols: { schemaVersion: 'v1' } }
+    );
+
+    expect(timeline.process).toHaveBeenCalledWith(
+      expect.objectContaining({
+        properties: {
+          id: 1,
+        },
+        context: {
+          library: {
+            name: 'test',
+            version: '1.0',
+          },
+          protocols: {
+            existing: true,
+            schemaVersion: 'v1',
+          },
+        },
+      })
     );
   });
 });

--- a/packages/core/src/__tests__/methods/screen.test.ts
+++ b/packages/core/src/__tests__/methods/screen.test.ts
@@ -44,5 +44,32 @@ describe('methods #screen', () => {
 
     expect(client.process).toHaveBeenCalledTimes(1);
     expect(client.process).toHaveBeenCalledWith(expectedEvent);
+    expect(
+      (client.process as jest.Mock).mock.calls[0][0].context
+    ).toBeUndefined();
+  });
+
+  it('stamps per-call context onto the screen event', async () => {
+    const client = new HightouchClient(clientArgs);
+    jest.spyOn(client, 'process');
+
+    await client.screen(
+      'Home Screen',
+      { id: 1 },
+      { protocols: { schemaVersion: 'v1' } }
+    );
+
+    expect(client.process).toHaveBeenCalledWith({
+      name: 'Home Screen',
+      properties: {
+        id: 1,
+      },
+      type: 'screen',
+      context: {
+        protocols: {
+          schemaVersion: 'v1',
+        },
+      },
+    });
   });
 });

--- a/packages/core/src/__tests__/methods/track.test.ts
+++ b/packages/core/src/__tests__/methods/track.test.ts
@@ -45,5 +45,33 @@ describe('methods #track', () => {
 
     expect(client.process).toHaveBeenCalledTimes(1);
     expect(client.process).toHaveBeenCalledWith(expectedEvent);
+    expect(
+      (client.process as jest.Mock).mock.calls[0][0].context
+    ).toBeUndefined();
+  });
+
+  it('stamps per-call context onto the track event without changing properties', async () => {
+    const client = new HightouchClient(clientArgs);
+    jest.spyOn(client, 'process');
+
+    await client.track(
+      'Some Event',
+      { id: 1 },
+      { protocols: { schemaVersion: 'v1' } }
+    );
+
+    expect(client.process).toHaveBeenCalledTimes(1);
+    expect(client.process).toHaveBeenCalledWith({
+      event: 'Some Event',
+      properties: {
+        id: 1,
+      },
+      type: EventType.TrackEvent,
+      context: {
+        protocols: {
+          schemaVersion: 'v1',
+        },
+      },
+    });
   });
 });

--- a/packages/core/src/analytics.ts
+++ b/packages/core/src/analytics.ts
@@ -708,47 +708,51 @@ export class HightouchClient {
     }
   }
 
-  async screen(name: string, options?: JsonMap) {
+  async screen(name: string, options?: JsonMap, context?: JsonMap) {
     const event = createScreenEvent({
       name,
       properties: options,
+      context,
     });
 
     await this.process(event);
     this.logger.info('SCREEN event saved', event);
   }
 
-  async track(eventName: string, options?: JsonMap) {
+  async track(eventName: string, options?: JsonMap, context?: JsonMap) {
     const event = createTrackEvent({
       event: eventName,
       properties: options,
+      context,
     });
 
     await this.process(event);
     this.logger.info('TRACK event saved', event);
   }
 
-  async identify(userId?: string, userTraits?: UserTraits) {
+  async identify(userId?: string, userTraits?: UserTraits, context?: JsonMap) {
     const event = createIdentifyEvent({
       userId: userId,
       userTraits: userTraits,
+      context,
     });
 
     await this.process(event);
     this.logger.info('IDENTIFY event saved', event);
   }
 
-  async group(groupId: string, groupTraits?: GroupTraits) {
+  async group(groupId: string, groupTraits?: GroupTraits, context?: JsonMap) {
     const event = createGroupEvent({
       groupId,
       groupTraits,
+      context,
     });
 
     await this.process(event);
     this.logger.info('GROUP event saved', event);
   }
 
-  async alias(newUserId: string) {
+  async alias(newUserId: string, context?: JsonMap) {
     // We don't use a concurrency safe version of get here as we don't want to lock the values yet,
     // we will update the values correctly when InjectUserInfo processes the change
     const { anonymousId, userId: previousUserId } = this.store.userInfo.get();
@@ -757,6 +761,7 @@ export class HightouchClient {
       anonymousId,
       userId: previousUserId,
       newUserId,
+      context,
     });
 
     await this.process(event);
@@ -1021,10 +1026,7 @@ export class HightouchClient {
     return {
       ...event,
       ...userInfo,
-      context: {
-        ...event.context,
-        ...context,
-      },
+      context: deepmerge(context ?? {}, event.context ?? {}),
     } as HightouchEvent;
   };
 

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -8,68 +8,84 @@ import {
   UserTraits,
   AliasEventType,
   EventType,
+  PartialContext,
 } from './types';
 
 export const createTrackEvent = ({
   event,
   properties = {},
+  context,
 }: {
   event: string;
   properties?: JsonMap;
+  context?: JsonMap;
 }): TrackEventType => ({
   type: EventType.TrackEvent,
   event,
   properties,
+  ...(context !== undefined ? { context: context as PartialContext } : {}),
 });
 
 export const createScreenEvent = ({
   name,
   properties = {},
+  context,
 }: {
   name: string;
   properties?: JsonMap;
+  context?: JsonMap;
 }): ScreenEventType => ({
   type: EventType.ScreenEvent,
   name,
   properties,
+  ...(context !== undefined ? { context: context as PartialContext } : {}),
 });
 
 export const createIdentifyEvent = ({
   userId,
   userTraits = {},
+  context,
 }: {
   userId?: string;
   userTraits?: UserTraits;
+  context?: JsonMap;
 }): IdentifyEventType => {
   return {
     type: EventType.IdentifyEvent,
     userId: userId,
     traits: userTraits,
+    ...(context !== undefined ? { context: context as PartialContext } : {}),
   };
 };
 
 export const createGroupEvent = ({
   groupId,
   groupTraits = {},
+  context,
 }: {
   groupId: string;
   groupTraits?: GroupTraits;
+  context?: JsonMap;
 }): GroupEventType => ({
   type: EventType.GroupEvent,
   groupId,
   traits: groupTraits,
+  ...(context !== undefined ? { context: context as PartialContext } : {}),
 });
 
 export const createAliasEvent = ({
   anonymousId,
   userId,
   newUserId,
+  context,
 }: {
   anonymousId: string;
   userId?: string;
   newUserId: string;
+  context?: JsonMap;
 }): AliasEventType => ({
   type: EventType.AliasEvent,
   userId: newUserId,
   previousId: userId ?? anonymousId,
+  ...(context !== undefined ? { context: context as PartialContext } : {}),
 });

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -156,12 +156,28 @@ export type Config = {
 };
 
 export type ClientMethods = {
-  screen: (name: string, properties?: JsonMap) => Promise<void>;
-  track: (event: string, properties?: JsonMap) => Promise<void>;
-  identify: (userId?: string, userTraits?: UserTraits) => Promise<void>;
+  screen: (
+    name: string,
+    properties?: JsonMap,
+    context?: JsonMap
+  ) => Promise<void>;
+  track: (
+    event: string,
+    properties?: JsonMap,
+    context?: JsonMap
+  ) => Promise<void>;
+  identify: (
+    userId?: string,
+    userTraits?: UserTraits,
+    context?: JsonMap
+  ) => Promise<void>;
   flush: () => Promise<void>;
-  group: (groupId: string, groupTraits?: GroupTraits) => Promise<void>;
-  alias: (newUserId: string) => Promise<void>;
+  group: (
+    groupId: string,
+    groupTraits?: GroupTraits,
+    context?: JsonMap
+  ) => Promise<void>;
+  alias: (newUserId: string, context?: JsonMap) => Promise<void>;
   reset: (resetAnonymousId?: boolean) => Promise<void>;
 };
 
@@ -233,6 +249,7 @@ export type Context = Partial<
   consent?: {
     categoryPreferences: Record<string, boolean>;
   };
+  protocols?: JsonMap;
 };
 
 /**


### PR DESCRIPTION
## Summary
- Add optional last-argument `context?: JsonMap` to `track`, `screen`, `identify`, `group`, and `alias` so generated wrappers can stamp `context.protocols.schemaVersion` per call (e.g. TrackFooV1 vs TrackFooV2) without a process-wide plugin.
- Stamp context on the event at call time and deep-merge it during process so nested maps sit next to existing context. Overlapping alias calls cannot swap context because it is not shared via a FIFO plugin queue.
- Source-compatible minor: existing second arguments stay properties/traits; omitted context is unchanged. Does not restore Segment Classic grab-bag options.

## Test plan
- [x] `track` with `{ protocols: { schemaVersion: "v1" } }` appears on the processed event context next to existing context
- [x] Two overlapping `alias` calls with different context do not swap
- [x] Omitted context does not change payloads
- [ ] CI green (lint, unit tests, e2e)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional per-event context support for screen, track, identify, group, and alias events.
  * Context data is preserved while events are pending and merged with stored context when processed.
  * Nested context values are merged without overwriting unrelated data.

* **Tests**
  * Added coverage for context handling across event types, including concurrent alias calls and protocol metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->