### PR TITLE
feat: add per-call enrichment closure to event methods

### DIFF
--- a/packages/core/src/__tests__/methods/group.test.ts
+++ b/packages/core/src/__tests__/methods/group.test.ts
@@ -43,6 +43,6 @@ describe('methods #group', () => {
     };
 
     expect(client.process).toHaveBeenCalledTimes(1);
-    expect(client.process).toHaveBeenCalledWith(expectedEvent);
+    expect(client.process).toHaveBeenCalledWith(expectedEvent, undefined);
   });
 });

--- a/packages/core/src/__tests__/methods/process.test.ts
+++ b/packages/core/src/__tests__/methods/process.test.ts
@@ -114,4 +114,191 @@ describe('process', () => {
       expect.objectContaining(expectedEvent)
     );
   });
+
+  it('enrichment closure gets applied', async () => {
+    const client = new HightouchClient(clientArgs);
+    jest.spyOn(client.isReady, 'value', 'get').mockReturnValue(true);
+
+    // @ts-ignore
+    const timeline = client.timeline;
+    jest.spyOn(timeline, 'process');
+
+    await client.track('Some Event', { id: 1 }, (event) => {
+      event.anonymousId = 'foo';
+      return event;
+    });
+
+    const expectedEvent = {
+      event: 'Some Event',
+      properties: {
+        id: 1,
+      },
+      type: EventType.TrackEvent,
+      context: { ...store.context.get() },
+      userId: store.userInfo.get().userId,
+      anonymousId: 'foo',
+    } as HightouchEvent;
+
+    // @ts-ignore
+    const pendingEvents = client.store.pendingEvents.get();
+    expect(pendingEvents.length).toBe(0);
+
+    expect(timeline.process).toHaveBeenCalledWith(
+      expect.objectContaining(expectedEvent)
+    );
+  });
+});
+
+describe('per-call enrichment closure', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const stampSchemaVersion =
+    (version: string) =>
+    (event: HightouchEvent): HightouchEvent => {
+      // `protocols` is not part of the SDK's Context type; per-call closures
+      // may stamp arbitrary context keys, hence the cast.
+      event.context = {
+        ...event.context,
+        protocols: { schemaVersion: version },
+      } as HightouchEvent['context'];
+      return event;
+    };
+
+  const getProtocols = (event?: HightouchEvent) =>
+    (event?.context as { protocols?: { schemaVersion?: string } } | undefined)
+      ?.protocols;
+
+  const setup = () => {
+    const testStore = new MockHightouchStore({
+      userInfo: {
+        userId: 'current-user-id',
+        anonymousId: 'very-anonymous',
+      },
+      context: {
+        library: {
+          name: 'test',
+          version: '1.0',
+        },
+        os: {
+          name: 'test-os',
+          version: '9.9',
+        },
+      },
+    });
+
+    const client = new HightouchClient({
+      config: {
+        writeKey: 'mock-write-key',
+        flushInterval: 0,
+      },
+      logger: getMockLogger(),
+      store: testStore,
+    });
+    jest.spyOn(client.isReady, 'value', 'get').mockReturnValue(true);
+
+    // @ts-ignore
+    const processSpy = jest.spyOn(client.timeline, 'process');
+
+    const processedEvents = () =>
+      Promise.all(
+        processSpy.mock.results.map(
+          (r) => r.value as Promise<HightouchEvent | undefined>
+        )
+      );
+
+    return { client, store: testStore, processedEvents };
+  };
+
+  it('overlapping alias calls keep their own enrichment stamps', async () => {
+    const { client, processedEvents } = setup();
+
+    // Fire both without awaiting so their processing overlaps
+    await Promise.all([
+      client.alias('first-new-user', stampSchemaVersion('alias-v1')),
+      client.alias('second-new-user', stampSchemaVersion('alias-v2')),
+    ]);
+
+    const processed = await processedEvents();
+    expect(processed).toHaveLength(2);
+
+    const first = processed.find((e) => e?.userId === 'first-new-user');
+    const second = processed.find((e) => e?.userId === 'second-new-user');
+    expect(first).toBeDefined();
+    expect(second).toBeDefined();
+    expect(getProtocols(first)?.schemaVersion).toBe('alias-v1');
+    expect(getProtocols(second)?.schemaVersion).toBe('alias-v2');
+  });
+
+  it('closure stamps context.protocols while platform context stays intact', async () => {
+    const { client, processedEvents } = setup();
+
+    await client.track(
+      'Stamped Event',
+      { id: 1 },
+      stampSchemaVersion('track-v1')
+    );
+
+    const [processed] = await processedEvents();
+    expect(getProtocols(processed)?.schemaVersion).toBe('track-v1');
+    expect(processed?.context?.library).toEqual({
+      name: 'test',
+      version: '1.0',
+    });
+    expect(processed?.context?.os).toEqual({
+      name: 'test-os',
+      version: '9.9',
+    });
+
+    // The closure never reaches the wire: functions are dropped by JSON serialization
+    const serialized = JSON.parse(JSON.stringify(processed)) as Record<
+      string,
+      unknown
+    >;
+    expect('enrichment' in serialized).toBe(false);
+  });
+
+  it('a later event without a closure has no protocols key in context', async () => {
+    const { client, processedEvents } = setup();
+
+    await client.track(
+      'Stamped Event',
+      { id: 1 },
+      stampSchemaVersion('track-v1')
+    );
+    await client.track('Plain Event', { id: 2 });
+
+    const processed = await processedEvents();
+    expect(processed).toHaveLength(2);
+
+    const plain = processed[1];
+    expect(getProtocols(plain)).toBeUndefined();
+    expect(Object.keys(plain?.context ?? {})).not.toContain('protocols');
+  });
+
+  it('omitted enrichment leaves the serialized payload unchanged', async () => {
+    const { client, store: testStore, processedEvents } = setup();
+
+    await client.track('No Closure', { id: 1 });
+
+    const [processed] = await processedEvents();
+    const serialized = JSON.parse(JSON.stringify(processed)) as Record<
+      string,
+      unknown
+    >;
+
+    expect('enrichment' in serialized).toBe(false);
+    expect(serialized).toEqual({
+      type: EventType.TrackEvent,
+      event: 'No Closure',
+      properties: { id: 1 },
+      context: { ...testStore.context.get() },
+      userId: 'current-user-id',
+      anonymousId: 'very-anonymous',
+      messageId: expect.any(String),
+      timestamp: '2999-01-01T00:00:00.000Z',
+      integrations: {},
+    });
+  });
 });

--- a/packages/core/src/__tests__/methods/process.test.ts
+++ b/packages/core/src/__tests__/methods/process.test.ts
@@ -1,6 +1,12 @@
 import { HightouchClient } from '../../analytics';
+import { Plugin } from '../../plugin';
 import { getMockLogger, MockHightouchStore } from '../../test-helpers';
-import { EventType, HightouchEvent } from '../../types';
+import {
+  EventType,
+  HightouchEvent,
+  PluginType,
+  TrackEventType,
+} from '../../types';
 
 jest.mock('uuid');
 
@@ -275,6 +281,43 @@ describe('per-call enrichment closure', () => {
     const plain = processed[1];
     expect(getProtocols(plain)).toBeUndefined();
     expect(Object.keys(plain?.context ?? {})).not.toContain('protocols');
+  });
+
+  it('closure survives a plugin that returns a brand-new event object', async () => {
+    const { client, processedEvents } = setup();
+
+    class ReplaceEventPlugin extends Plugin {
+      type = PluginType.enrichment;
+      execute(event: HightouchEvent): HightouchEvent {
+        // Brand-new object literal, deliberately NOT a spread of the incoming
+        // event, so it carries no `enrichment` key.
+        return {
+          type: EventType.TrackEvent,
+          event: 'Replaced Event',
+          properties: { replaced: true },
+          messageId: event.messageId,
+          timestamp: event.timestamp,
+          context: event.context,
+          anonymousId: event.anonymousId,
+          userId: event.userId,
+          integrations: {},
+        };
+      }
+    }
+    client.add({ plugin: new ReplaceEventPlugin() });
+
+    await client.track(
+      'Original Event',
+      { id: 1 },
+      stampSchemaVersion('replaced-v1')
+    );
+
+    const [processed] = await processedEvents();
+    expect((processed as TrackEventType).event).toBe('Replaced Event');
+    expect((processed as TrackEventType).properties).toEqual({
+      replaced: true,
+    });
+    expect(getProtocols(processed)?.schemaVersion).toBe('replaced-v1');
   });
 
   it('omitted enrichment leaves the serialized payload unchanged', async () => {

--- a/packages/core/src/__tests__/methods/screen.test.ts
+++ b/packages/core/src/__tests__/methods/screen.test.ts
@@ -43,6 +43,6 @@ describe('methods #screen', () => {
     };
 
     expect(client.process).toHaveBeenCalledTimes(1);
-    expect(client.process).toHaveBeenCalledWith(expectedEvent);
+    expect(client.process).toHaveBeenCalledWith(expectedEvent, undefined);
   });
 });

--- a/packages/core/src/__tests__/methods/track.test.ts
+++ b/packages/core/src/__tests__/methods/track.test.ts
@@ -44,6 +44,6 @@ describe('methods #track', () => {
     };
 
     expect(client.process).toHaveBeenCalledTimes(1);
-    expect(client.process).toHaveBeenCalledWith(expectedEvent);
+    expect(client.process).toHaveBeenCalledWith(expectedEvent, undefined);
   });
 });

--- a/packages/core/src/analytics.ts
+++ b/packages/core/src/analytics.ts
@@ -46,6 +46,7 @@ import {
   Config,
   Context,
   DeepPartial,
+  EnrichmentClosure,
   GroupTraits,
   IntegrationSettings,
   JsonMap,
@@ -525,9 +526,10 @@ export class HightouchClient {
     this.timeline.remove(plugin);
   }
 
-  async process(incomingEvent: HightouchEvent) {
+  async process(incomingEvent: HightouchEvent, enrichment?: EnrichmentClosure) {
     return this.runProcess(async () => {
       const event = this.applyRawEventData(incomingEvent);
+      event.enrichment = enrichment;
 
       if (this.isReady.value) {
         return await this.startTimelineProcessing(event);
@@ -708,47 +710,63 @@ export class HightouchClient {
     }
   }
 
-  async screen(name: string, options?: JsonMap) {
+  async screen(
+    name: string,
+    options?: JsonMap,
+    enrichment?: EnrichmentClosure
+  ) {
     const event = createScreenEvent({
       name,
       properties: options,
     });
 
-    await this.process(event);
+    await this.process(event, enrichment);
     this.logger.info('SCREEN event saved', event);
   }
 
-  async track(eventName: string, options?: JsonMap) {
+  async track(
+    eventName: string,
+    options?: JsonMap,
+    enrichment?: EnrichmentClosure
+  ) {
     const event = createTrackEvent({
       event: eventName,
       properties: options,
     });
 
-    await this.process(event);
+    await this.process(event, enrichment);
     this.logger.info('TRACK event saved', event);
   }
 
-  async identify(userId?: string, userTraits?: UserTraits) {
+  async identify(
+    userId?: string,
+    userTraits?: UserTraits,
+    enrichment?: EnrichmentClosure
+  ) {
     const event = createIdentifyEvent({
       userId: userId,
       userTraits: userTraits,
     });
 
-    await this.process(event);
+    await this.process(event, enrichment);
     this.logger.info('IDENTIFY event saved', event);
   }
 
-  async group(groupId: string, groupTraits?: GroupTraits) {
+  async group(
+    groupId: string,
+    groupTraits?: GroupTraits,
+    enrichment?: EnrichmentClosure
+  ) {
     const event = createGroupEvent({
       groupId,
       groupTraits,
     });
 
-    await this.process(event);
+    await this.process(event, enrichment);
     this.logger.info('GROUP event saved', event);
   }
 
-  async alias(newUserId: string) {
+  async alias(newUserId: string, enrichment?: EnrichmentClosure) {
     // We don't use a concurrency safe version of get here as we don't want to lock the values yet,
     // we will update the values correctly when InjectUserInfo processes the change
     const { anonymousId, userId: previousUserId } = this.store.userInfo.get();
@@ -759,7 +777,7 @@ export class HightouchClient {
       newUserId,
     });
 
-    await this.process(event);
+    await this.process(event, enrichment);
     this.logger.info('ALIAS event saved', event);
   }
 

--- a/packages/core/src/timeline.ts
+++ b/packages/core/src/timeline.ts
@@ -70,6 +70,12 @@ export class Timeline {
       if (key !== PluginType.destination) {
         if (result === undefined) {
           return;
+        } else if (
+          key === PluginType.enrichment &&
+          pluginResult?.enrichment &&
+          typeof pluginResult.enrichment === 'function'
+        ) {
+          result = pluginResult.enrichment(pluginResult);
         } else {
           result = pluginResult;
         }

--- a/packages/core/src/timeline.ts
+++ b/packages/core/src/timeline.ts
@@ -59,6 +59,8 @@ export class Timeline {
   async process(
     incomingEvent: HightouchEvent
   ): Promise<HightouchEvent | undefined> {
+    // Deliberate divergence from Segment upstream: capture the per-call enrichment up front so it survives plugins that return a fresh event (upstream drops it).
+    const enrichment = incomingEvent.enrichment;
     let result: HightouchEvent | undefined = incomingEvent;
 
     for (const key of PLUGIN_ORDER) {
@@ -72,10 +74,10 @@ export class Timeline {
           return;
         } else if (
           key === PluginType.enrichment &&
-          pluginResult?.enrichment &&
-          typeof pluginResult.enrichment === 'function'
+          pluginResult !== undefined &&
+          typeof enrichment === 'function'
         ) {
-          result = pluginResult.enrichment(pluginResult);
+          result = enrichment(pluginResult);
         } else {
           result = pluginResult;
         }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -34,6 +34,7 @@ interface BaseEventType {
   context?: PartialContext;
   integrations?: HightouchAPIIntegrations;
   _metadata?: DestinationMetadata;
+  enrichment?: EnrichmentClosure;
 }
 
 export interface TrackEventType extends BaseEventType {
@@ -156,12 +157,28 @@ export type Config = {
 };
 
 export type ClientMethods = {
-  screen: (name: string, properties?: JsonMap) => Promise<void>;
-  track: (event: string, properties?: JsonMap) => Promise<void>;
-  identify: (userId?: string, userTraits?: UserTraits) => Promise<void>;
+  screen: (
+    name: string,
+    properties?: JsonMap,
+    enrichment?: EnrichmentClosure
+  ) => Promise<void>;
+  track: (
+    event: string,
+    properties?: JsonMap,
+    enrichment?: EnrichmentClosure
+  ) => Promise<void>;
+  identify: (
+    userId?: string,
+    userTraits?: UserTraits,
+    enrichment?: EnrichmentClosure
+  ) => Promise<void>;
   flush: () => Promise<void>;
-  group: (groupId: string, groupTraits?: GroupTraits) => Promise<void>;
-  alias: (newUserId: string) => Promise<void>;
+  group: (
+    groupId: string,
+    groupTraits?: GroupTraits,
+    enrichment?: EnrichmentClosure
+  ) => Promise<void>;
+  alias: (newUserId: string, enrichment?: EnrichmentClosure) => Promise<void>;
   reset: (resetAnonymousId?: boolean) => Promise<void>;
 };
 
@@ -391,3 +408,5 @@ export interface GetContextConfig {
 export type AnalyticsReactNativeModule = NativeModule & {
   getContextInfo: (config: GetContextConfig) => Promise<NativeContextInfo>;
 };
+
+export type EnrichmentClosure = (event: HightouchEvent) => HightouchEvent;


### PR DESCRIPTION
## Summary

Adds an upstream-parity, per-call `enrichment?: EnrichmentClosure` trailing parameter to `track`, `screen`, `identify`, `group`, and `alias`:

```ts
export type EnrichmentClosure = (event: HightouchEvent) => HightouchEvent;

client.track('Order Completed', { total: 42 }, (event) => {
  event.context = { ...event.context, protocols: { schemaVersion: 'v2' } };
  return event;
});
```

- The closure is stashed on the event in `process()` and executed in the timeline **after** enrichment-type plugins, so platform context (library/os/device/etc.) is already stamped when it runs.
- The closure's return value is taken **verbatim** — there is no core-side merging. Merge semantics belong in the caller's closure.
- Generated typed event wrappers can use this to stamp `context.protocols.schemaVersion` per call without process-wide plugin add/remove races.
- The closure never reaches the wire: function values are dropped by JSON serialization in the upload path, same as upstream.

## Deliberate divergence

Processing semantics match upstream **except** for one internal hardening: `Timeline.process` captures the per-call closure into a local **before** any plugin phase runs, so it survives plugins that return a brand-new event object. Upstream reads the closure off the post-plugin event and silently drops it in that case. This is marked with a one-line comment at the capture site and covered by a regression test. The public API shape (parameter name, position, type, optionality) remains byte-identical to upstream.

## Rationale

Supersedes https://github.com/ht-sdks/events-sdk-react-native/pull/29. That PR claimed the same trailing positional argument slot that upstream segmentio/analytics-react-native uses for its per-call enrichment closure, which would break future upstream syncs. This PR reimplements the upstream API shape exactly (parameter name, position, type, optionality) so future syncs stay conflict-free at the API surface.

Existing method signatures remain source-compatible — the new parameter is optional and trailing.

## Known limitation

Enrichment closures do not survive persistence of pending events across process death (functions don't serialize); in-memory replay within the same session works. This matches upstream behavior.

## Test plan

New tests in `packages/core/src/__tests__/methods/process.test.ts`:

- `enrichment closure gets applied` — adapted from upstream's process.test.ts.
- Two overlapping `alias` calls with different closures (each stamping a different `context.protocols.schemaVersion`) keep their own stamps — no cross-contamination between concurrent events.
- A `track` with a closure stamping `context.protocols.schemaVersion` keeps platform context (`library`/`os`) intact, and the serialized event contains no `enrichment` key.
- A later event without a closure has no `protocols` key in context.
- Omitted enrichment leaves the serialized payload unchanged (deep-equal of the full serialized processed event; no `enrichment` key present).
- Regression: an enrichment-type plugin whose `execute()` returns a brand-new event object literal (no `enrichment` key carried over) — the per-call closure still runs and its stamp appears on the processed event.

Also updated `track`/`screen`/`group` method tests to assert `process(event, undefined)`, mirroring upstream's test updates for the same change.

Local checks run (matching `.github/workflows/ci.yml` build-and-test):

- `yarn install --immutable` — OK
- `yarn build` (all workspaces, includes tsc type generation) — OK
- `yarn lint` — 0 errors (warnings pre-existing, count reduced by one)
- `yarn test --coverage` — 67 suites passed, 310 tests passed, 29 skipped (pre-existing), 1 todo

Detox e2e jobs (iOS/Android simulators) left to CI.

## Licensing

Upstream analytics-react-native is MIT-licensed; this is a native reimplementation of the same API shape in this fork (which shares that lineage). Existing license attribution files are untouched.